### PR TITLE
Improve proxy support

### DIFF
--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -100,7 +100,7 @@ export function parseConfig (config: ConfigJson, path: string): ConfigJson {
  */
 export function readHttp (url: string): Promise<string> {
   const { proxy, rejectUnauthorized, ca, key, cert, userAgent } = rc
-  const agent = proxy ? new ProxyAgent(proxy) : null
+  const agent = proxy ? new ProxyAgent(proxy) : process.env.HTTP_PROXY ? new ProxyAgent( process.env.HTTP_PROXY ) : null
 
   return popsicle.get({
     url,


### PR DESCRIPTION
Added HTTP_PROXY environment variable as an alternative to use proxy with typings, so people can use it without having to write the .typingsrc file.
